### PR TITLE
Fix setting up environmental variables in users shell config file

### DIFF
--- a/pg-install.sh
+++ b/pg-install.sh
@@ -96,7 +96,7 @@ $PROFILEFILE not updated, $INSTALLDIR is already mentioned there, so assuming th
 else
 echo "LD_LIBRARY_PATH=$INSTALLDIR/lib
 export LD_LIBRARY_PATH
-PATH=$INSTALLDIR/bin:$PATH
+PATH=$INSTALLDIR/bin:\$PATH
 export PATH
 PGHOST=$INSTALLDIR/sock
 export PGHOST
@@ -115,7 +115,7 @@ fi
 
 echo "LD_LIBRARY_PATH=$INSTALLDIR/lib
 export LD_LIBRARY_PATH
-PATH=$INSTALLDIR/bin:$PATH
+PATH=$INSTALLDIR/bin:\$PATH
 export PATH
 PGHOST=$INSTALLDIR/sock
 export PGHOST

--- a/pg-install.sh
+++ b/pg-install.sh
@@ -87,6 +87,10 @@ make
 make install-strip
 
 # update profile file
+env_vars="export LD_LIBRARY_PATH=$INSTALLDIR/lib
+export PATH=$INSTALLDIR/bin:\$PATH
+export PGHOST=$INSTALLDIR/sock
+export PGDATA=$INSTALLDIR/data"
 
 if [ -f "$PROFILEFILE" ]; then
 if grep -q "$INSTALLDIR" "$PROFILEFILE" 2>/dev/null; then
@@ -94,14 +98,7 @@ echo "
 $PROFILEFILE not updated, $INSTALLDIR is already mentioned there, so assuming this is reinstall and it is up to date.
 "
 else
-echo "LD_LIBRARY_PATH=$INSTALLDIR/lib
-export LD_LIBRARY_PATH
-PATH=$INSTALLDIR/bin:\$PATH
-export PATH
-PGHOST=$INSTALLDIR/sock
-export PGHOST
-PGDATA=$INSTALLDIR/data
-export PGDATA" >> "$PROFILEFILE"
+echo "$env_vars" >> "$PROFILEFILE"
 echo "
 Added environment variables to $PROFILEFILE
 "
@@ -113,14 +110,7 @@ Added environment variables to $INSTALLDIR/README.environment, copy these manual
 "
 fi
 
-echo "LD_LIBRARY_PATH=$INSTALLDIR/lib
-export LD_LIBRARY_PATH
-PATH=$INSTALLDIR/bin:\$PATH
-export PATH
-PGHOST=$INSTALLDIR/sock
-export PGHOST
-PGDATA=$INSTALLDIR/data
-export PGDATA" >> "$INSTALLDIR/README.environment"
+echo "$env_vars" >> "$INSTALLDIR/README.environment"
 
 # modify default config to use only sockets
 


### PR DESCRIPTION
This PR adds a couple of fixes:
- We shouldn't expand PATH in this script, since PATH will likely change at some point after the local-pg has been installed. 
- move env variables string to one variable, make it a bit more readable